### PR TITLE
Support SPI, BMA253, more features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ repository = "https://github.com/RandomInsano/bma2xx"
 
 [dependencies]
 embedded-hal = "0.2.2"
+bitfield = "0.13.2"

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,0 +1,186 @@
+//! This module defines a trait for interfacing with the registers on a bma2xx, as well as
+//! implementations for both I2C and SPI.
+use crate::register::Reg;
+use hal::blocking::{i2c, spi};
+use hal::digital::v2::OutputPin;
+
+/// Represents a digital interface with a bma2xx.
+pub trait DigitalInterface {
+    /// The type of errors the underlying digital interface generates.
+    type Error;
+    /// Read data.len() bytes from register into data.
+    fn read_multiple(&mut self, register: Reg, data: &mut [u8]) -> Result<(), Self::Error>;
+    /// Write data.len() bytes in data to a register.
+    fn write_multiple(&mut self, register: Reg, data: &[u8]) -> Result<(), Self::Error>;
+    /// Read a single byte from a register.
+    fn read(&mut self, register: Reg) -> Result<u8, Self::Error>;
+    /// Write a singly byte to a register.
+    fn write(&mut self, register: Reg, data: u8) -> Result<(), Self::Error>;
+}
+
+/// Default I2C device address when SDO pin is pulled to GND.
+pub const I2C_DEFAULT_ADDRESS: u8 = 0x18;
+
+/// Alternate I2C device address when SDO pin is pulled to VDDIO.
+pub const I2C_ALTERNATE_ADDRESS: u8 = 0x19;
+
+/// Represents digital interface with a bma2xx device over I2C.
+pub struct I2CInterface<I2C> {
+    device: I2C,
+    address: u8,
+}
+
+impl<I2C, E> I2CInterface<I2C>
+where
+    I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+{
+    /// Create a new digital interface based on an I2C device.
+    pub fn new(device: I2C, address: u8) -> I2CInterface<I2C> {
+        I2CInterface {
+            device: device,
+            address: address,
+        }
+    }
+}
+
+impl<I2C, E> DigitalInterface for I2CInterface<I2C>
+where
+    I2C: i2c::WriteRead<Error = E> + i2c::Write<Error = E>,
+{
+    type Error = E;
+
+    fn read_multiple(&mut self, register: Reg, data: &mut [u8]) -> Result<(), E> {
+        self.device
+            .write_read(self.address, &[register as u8], data)
+    }
+
+    fn write_multiple(&mut self, register: Reg, data: &[u8]) -> Result<(), E> {
+        let mut input = [0u8; 16]; // Can't dynamically size this, so 16 it is!
+        assert!(
+            data.len() < 16 - 1,
+            "write_multiple() can only take buffers up to 15 bytes"
+        );
+
+        input[1..=data.len()].copy_from_slice(data);
+        input[0] = register as u8;
+
+        self.device.write(self.address, &input)?;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn read(&mut self, register: Reg) -> Result<u8, E> {
+        let mut out = [0];
+        self.device
+            .write_read(self.address, &[register as u8], &mut out)?;
+        Ok(out[0])
+    }
+
+    #[inline]
+    fn write(&mut self, register: Reg, data: u8) -> Result<(), E> {
+        self.device.write(self.address, &[register as u8, data])
+    }
+}
+
+const SPI_READ_BIT: u8 = 0x80;
+const SPI_WRITE_MASK: u8 = 0x7f;
+
+/// An error caused by the SPI digital interface.
+#[derive(Debug, Copy, Clone)]
+pub enum SpiError<E, E2> {
+    /// SPI bus I/O error
+    BusError(E),
+    /// Error setting the nCS pin
+    NCSError(E2),
+}
+
+/// Represents digital interface with a bma2xx device over SPI.
+pub struct SPIInterface<SPI, NSS> {
+    device: SPI,
+    nss: NSS,
+}
+
+impl<SPI, NSS, E, EO> SPIInterface<SPI, NSS>
+where
+    SPI: spi::Transfer<u8, Error = E> + spi::Write<u8, Error = E>,
+    NSS: OutputPin<Error = EO>,
+{
+    /// Create a new digital interface based on a SPI device and a
+    /// notSlaveSelect OutputPin.
+    pub fn new(device: SPI, nss: NSS) -> Result<SPIInterface<SPI, NSS>, SpiError<E, EO>> {
+        let mut result = SPIInterface {
+            device: device,
+            nss: nss,
+        };
+
+        result.nss.set_high().map_err(SpiError::NCSError)?;
+        Ok(result)
+    }
+
+    #[inline]
+    fn transfer<'w>(&mut self, buffer: &'w mut [u8]) -> Result<&'w [u8], SpiError<E, EO>> {
+        self.nss.set_low().map_err(SpiError::NCSError)?;
+        let result = self.device.transfer(buffer).map_err(SpiError::BusError);
+        self.nss.set_high().map_err(SpiError::NCSError)?;
+        result
+    }
+
+    #[inline]
+    fn write(&mut self, buffer: &[u8]) -> Result<(), SpiError<E, EO>> {
+        self.nss.set_low().map_err(SpiError::NCSError)?;
+        let result = self.device.write(buffer).map_err(SpiError::BusError);
+        self.nss.set_high().map_err(SpiError::NCSError)?;
+        result
+    }
+}
+
+impl<SPI, NSS, E, EO> DigitalInterface for SPIInterface<SPI, NSS>
+where
+    SPI: spi::Transfer<u8, Error = E> + spi::Write<u8, Error = E>,
+    NSS: OutputPin<Error = EO>,
+{
+    type Error = SpiError<E, EO>;
+
+    fn write_multiple(&mut self, register: Reg, data: &[u8]) -> Result<(), Self::Error> {
+        let mut input = [0; 16]; // Can't dynamically size this, so 16 it is!
+        assert!(
+            data.len() < 16 - 1,
+            "write_multiple() can only take buffers up to 15 bytes"
+        );
+
+        input[1..data.len() + 1].copy_from_slice(data);
+        input[0] = register as u8 & SPI_WRITE_MASK;
+
+        self.write(&input[..data.len() + 1])?;
+
+        Ok(())
+    }
+
+    fn read_multiple(&mut self, reg: Reg, data: &mut [u8]) -> Result<(), Self::Error> {
+        let mut buf = [0; 16]; // Can't dynamically size this, so 16 it is!
+        assert!(
+            data.len() < 16 - 1,
+            "read_multiple() can only take buffers up to 15 bytes"
+        );
+
+        buf[0] = reg as u8 | SPI_READ_BIT;
+
+        let out = self.transfer(&mut buf[..data.len() + 1])?;
+        data.copy_from_slice(&out[1..data.len() + 1]);
+        Ok(())
+    }
+
+    #[inline]
+    fn read(&mut self, reg: Reg) -> Result<u8, Self::Error> {
+        let mut buf = [reg as u8 | SPI_READ_BIT, 0];
+        let out = self.transfer(&mut buf)?;
+        Ok(out[1])
+    }
+
+    #[inline]
+    fn write(&mut self, reg: Reg, data: u8) -> Result<(), Self::Error> {
+        let mut buf = [reg as u8 & SPI_WRITE_MASK, data];
+        self.write(&mut buf)
+    }
+}

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -88,7 +88,7 @@ const SPI_WRITE_MASK: u8 = 0x7f;
 
 /// An error caused by the SPI digital interface.
 #[derive(Debug, Copy, Clone)]
-pub enum SpiError<E, E2> {
+pub enum SPIError<E, E2> {
     /// SPI bus I/O error
     BusError(E),
     /// Error setting the nCS pin
@@ -108,29 +108,29 @@ where
 {
     /// Create a new digital interface based on a SPI device and a
     /// notSlaveSelect OutputPin.
-    pub fn new(device: SPI, nss: NSS) -> Result<SPIInterface<SPI, NSS>, SpiError<E, EO>> {
+    pub fn new(device: SPI, nss: NSS) -> Result<SPIInterface<SPI, NSS>, SPIError<E, EO>> {
         let mut result = SPIInterface {
             device: device,
             nss: nss,
         };
 
-        result.nss.set_high().map_err(SpiError::NCSError)?;
+        result.nss.set_high().map_err(SPIError::NCSError)?;
         Ok(result)
     }
 
     #[inline]
-    fn transfer<'w>(&mut self, buffer: &'w mut [u8]) -> Result<&'w [u8], SpiError<E, EO>> {
-        self.nss.set_low().map_err(SpiError::NCSError)?;
-        let result = self.device.transfer(buffer).map_err(SpiError::BusError);
-        self.nss.set_high().map_err(SpiError::NCSError)?;
+    fn transfer<'w>(&mut self, buffer: &'w mut [u8]) -> Result<&'w [u8], SPIError<E, EO>> {
+        self.nss.set_low().map_err(SPIError::NCSError)?;
+        let result = self.device.transfer(buffer).map_err(SPIError::BusError);
+        self.nss.set_high().map_err(SPIError::NCSError)?;
         result
     }
 
     #[inline]
-    fn write(&mut self, buffer: &[u8]) -> Result<(), SpiError<E, EO>> {
-        self.nss.set_low().map_err(SpiError::NCSError)?;
-        let result = self.device.write(buffer).map_err(SpiError::BusError);
-        self.nss.set_high().map_err(SpiError::NCSError)?;
+    fn write(&mut self, buffer: &[u8]) -> Result<(), SPIError<E, EO>> {
+        self.nss.set_low().map_err(SPIError::NCSError)?;
+        let result = self.device.write(buffer).map_err(SPIError::BusError);
+        self.nss.set_high().map_err(SPIError::NCSError)?;
         result
     }
 }
@@ -140,7 +140,7 @@ where
     SPI: spi::Transfer<u8, Error = E> + spi::Write<u8, Error = E>,
     NSS: OutputPin<Error = EO>,
 {
-    type Error = SpiError<E, EO>;
+    type Error = SPIError<E, EO>;
 
     fn write_multiple(&mut self, register: Reg, data: &[u8]) -> Result<(), Self::Error> {
         let mut input = [0; 16]; // Can't dynamically size this, so 16 it is!

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -24,6 +24,9 @@ pub const I2C_DEFAULT_ADDRESS: u8 = 0x18;
 /// Alternate I2C device address when SDO pin is pulled to VDDIO.
 pub const I2C_ALTERNATE_ADDRESS: u8 = 0x19;
 
+const SPI_READ_BIT: u8 = 0x80;
+const SPI_WRITE_MASK: u8 = 0x7f;
+
 /// Represents digital interface with a bma2xx device over I2C.
 pub struct I2CInterface<I2C> {
     device: I2C,
@@ -83,16 +86,13 @@ where
     }
 }
 
-const SPI_READ_BIT: u8 = 0x80;
-const SPI_WRITE_MASK: u8 = 0x7f;
-
 /// An error caused by the SPI digital interface.
 #[derive(Debug, Copy, Clone)]
 pub enum SPIError<E, E2> {
     /// SPI bus I/O error
     BusError(E),
-    /// Error setting the nCS pin
-    NCSError(E2),
+    /// Error setting the nSS pin
+    NSSError(E2),
 }
 
 /// Represents digital interface with a bma2xx device over SPI.
@@ -114,23 +114,23 @@ where
             nss: nss,
         };
 
-        result.nss.set_high().map_err(SPIError::NCSError)?;
+        result.nss.set_high().map_err(SPIError::NSSError)?;
         Ok(result)
     }
 
     #[inline]
     fn transfer<'w>(&mut self, buffer: &'w mut [u8]) -> Result<&'w [u8], SPIError<E, EO>> {
-        self.nss.set_low().map_err(SPIError::NCSError)?;
+        self.nss.set_low().map_err(SPIError::NSSError)?;
         let result = self.device.transfer(buffer).map_err(SPIError::BusError);
-        self.nss.set_high().map_err(SPIError::NCSError)?;
+        self.nss.set_high().map_err(SPIError::NSSError)?;
         result
     }
 
     #[inline]
     fn write(&mut self, buffer: &[u8]) -> Result<(), SPIError<E, EO>> {
-        self.nss.set_low().map_err(SPIError::NCSError)?;
+        self.nss.set_low().map_err(SPIError::NSSError)?;
         let result = self.device.write(buffer).map_err(SPIError::BusError);
-        self.nss.set_high().map_err(SPIError::NCSError)?;
+        self.nss.set_high().map_err(SPIError::NSSError)?;
         result
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,6 @@
 //! * BMA255 - 12bit resolution
 //! * BMA280 - 14bit resolution
 //!
-//! Specifically, these chips should work with the library now, but
-//! you wouldn't benefit from the enhanced resolution.
-//!
 //! More info on the product line from Bosch's website:
 //! https://www.bosch-sensortec.com/bst/products/all_products/bma222e
 //!
@@ -117,12 +114,12 @@ pub mod interface;
 pub mod register;
 
 use core::fmt;
-//use hal::blocking::{i2c, spi};
 use crate::interface::DigitalInterface;
 use crate::register::Reg;
 use bitfield::{Bit, BitRange};
 
 const MAX_NVM_LENGTH: usize = 8;
+const RESET_MAGIC_VALUE: u8 = 0xb6;
 
 /// Implements chip-specific values.
 pub trait Bma2xx {
@@ -226,8 +223,6 @@ impl<I, B> Accelerometer<I, B> {
         }
     }
 }
-
-const RESET_MAGIC_VALUE: u8 = 0xb6;
 
 /// Various FIFO operating modes
 pub enum FIFOConfig {

--- a/src/register.rs
+++ b/src/register.rs
@@ -1,0 +1,67 @@
+//! This module defines the registers any bma2xx might support. For more
+//! details, see the chapter on register descriptions in the data sheet for your
+//! specific bma2xx.
+
+/// See the chapter on register descriptions in the data sheet for your specific
+/// bma2xx.
+#[allow(non_camel_case_types)]
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy)]
+#[repr(u8)]
+pub enum Reg {
+    BGW_CHIPID = 0x00,
+    ACCD_X_LSB = 0x02,
+    ACCD_X_MSB = 0x03,
+    ACCD_Y_LSB = 0x04,
+    ACCD_Y_MSB = 0x05,
+    ACCD_Z_LSB = 0x06,
+    ACCD_Z_MSB = 0x07,
+    ACCD_TEMP = 0x08,
+    INT_STATUS_0 = 0x09,
+    INT_STATUS_1 = 0x0a,
+    INT_STATUS_2 = 0x0b,
+    INT_STATUS_3 = 0x0c,
+    FIFO_STATUS = 0x0e,
+    PMU_RANGE = 0x0f,
+    PMU_BW = 0x10,
+    PMU_LPW = 0x11,
+    PMU_LOW_POWER = 0x12,
+    ACCD_HBW = 0x13,
+    BGW_SOFTRESET = 0x14,
+    INT_EN_0 = 0x16,
+    INT_EN_1 = 0x17,
+    INT_EN_2 = 0x18,
+    INT_MAP_0 = 0x19,
+    INT_MAP_1 = 0x1a,
+    INT_MAP_2 = 0x1b,
+    INT_SRC = 0x1e,
+    INT_OUT_CTRL = 0x20,
+    INT_RST_LATCH = 0x21,
+    INT_0 = 0x22,
+    INT_1 = 0x23,
+    INT_2 = 0x24,
+    INT_3 = 0x25,
+    INT_4 = 0x26,
+    INT_5 = 0x27,
+    INT_6 = 0x28,
+    INT_7 = 0x29,
+    INT_8 = 0x2a,
+    INT_9 = 0x2b,
+    INT_A = 0x2c,
+    INT_B = 0x2d,
+    INT_C = 0x2e,
+    INT_D = 0x2f,
+    FIFO_CONFIG_0 = 0x30,
+    PMU_SELF_TEST = 0x32,
+    TRIM_NVM_CTRL = 0x33,
+    BGW_SPI3_WDT = 0x34,
+    OFC_CTRL = 0x36,
+    OFC_SETTING = 0x37,
+    OFC_OFFSET_X = 0x38,
+    OFC_OFFSET_Y = 0x39,
+    OFC_OFFSET_Z = 0x3a,
+    TRIM_GP0 = 0x3b,
+    TRIM_GP1 = 0x3c,
+    FIFO_CONFIG_1 = 0x3e,
+    FIFO_DATA = 0x3f,
+}


### PR DESCRIPTION
This is a rewrite of a significant part of the library:

I moved the I2C communication code to interface.rs, abstracted over it
and added support for SPI communication. I also added support for the
bma253, which I'm currently working with. I created another trait to
abstract over the details of each bma2xx. I also created register.rs
which lists all registers described in the bma253 data sheet, using the
names from that data sheet so they are easy to look up. Finally, I
implemented configuration of the tap sensing feature.

I haven't tested these changes with the bma222e or with I2C as I don't
have the hardware for that, but I have mostly left that code alone so I
still expect it to work. There are some breaking changes in how to
create an instance of the device, see the changes to the documentation
for that.