### PR TITLE
Fix reversed bit indices, support g-range, remove unreachable errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,7 @@ where
 
     fn set_range(&mut self, range: RangeConfig) -> Result<(), Self::Error> {
         let mut pmu_range = 0;
-        pmu_range.set_bit_range(0, 3, range as u8);
+        pmu_range.set_bit_range(3, 0, range as u8);
         self.interface.write(Reg::PMU_RANGE, pmu_range)
     }
 
@@ -403,13 +403,13 @@ where
         int_en_0.set_bit(5, cfg.single_tap_enabled);
         self.interface.write(Reg::INT_EN_0, int_en_0)?;
         let mut int_8 = 0u8;
-        int_8.set_bit_range(0, 2, cfg.double_tap_duration as u8);
+        int_8.set_bit_range(2, 0, cfg.double_tap_duration as u8);
         int_8.set_bit(6, cfg.tap_shock_duration.into());
         int_8.set_bit(7, cfg.tap_quiet_duration.into());
         self.interface.write(Reg::INT_8, int_8)?;
         let mut int_9 = 0u8;
-        int_9.set_bit_range(0, 4, cfg.tap_threshold & 0x1f);
-        int_9.set_bit_range(6, 7, cfg.tap_wakeup_samples as u8);
+        int_9.set_bit_range(4, 0, cfg.tap_threshold & 0x1f);
+        int_9.set_bit_range(7, 6, cfg.tap_wakeup_samples as u8);
         self.interface.write(Reg::INT_9, int_9)?;
         let mut int_map_0 = self.interface.read(Reg::INT_MAP_0)?;
         int_map_0.set_bit(4, cfg.map_double_to_int1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,9 @@ pub trait AccelerometerExt {
     /// compare this value to REG_CHIPID.
     fn who_am_i(&mut self) -> Result<u8, Self::Error>;
 
+    /// Set the accelerometer g-range.
+    fn set_range(&mut self, range: RangeConfig) -> Result<(), Self::Error>;
+
     /// Configure tap sensing.
     fn configure_tap_sensing(&mut self, cfg: TapSensingConfig) -> Result<(), Self::Error>;
 
@@ -313,6 +316,15 @@ pub enum TapWakeupSamples {
     _16samples = 3,
 }
 
+#[allow(missing_docs)]
+#[derive(Copy, Clone, Debug)]
+pub enum RangeConfig {
+    _2g = 3,
+    _4g = 5,
+    _8g = 8,
+    _16g = 12,
+}
+
 /// Configuration for tap sensing.
 #[derive(Copy, Clone, Debug)]
 pub struct TapSensingConfig {
@@ -377,6 +389,12 @@ where
 
     fn who_am_i(&mut self) -> Result<u8, E> {
         Ok(self.interface.read(Reg::BGW_CHIPID)?)
+    }
+
+    fn set_range(&mut self, range: RangeConfig) -> Result<(), Self::Error> {
+        let mut pmu_range = 0;
+        pmu_range.set_bit_range(0, 3, range as u8);
+        self.interface.write(Reg::PMU_RANGE, pmu_range)
     }
 
     fn configure_tap_sensing(&mut self, cfg: TapSensingConfig) -> Result<(), E> {


### PR DESCRIPTION
I found out all implementations of `OutputPin` have `Error = Infallible` in practice, so I simplified error handling by requiring that. This also means the constructor can no longer fail and eat the relevant peripherals. This was a big oversight of me. I also included two other small commits I forgot to upstream earlier.